### PR TITLE
fix typo broken link

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ Draft IVOA JSON encoding
 
 .. seealso::
 
-   :sqr:`91`: Draft IVOA web service standards framework
+   :sqr:`091`: Draft IVOA web service standards framework
        The draft protocol structure for IVOA web services.
        This specifies what should be included in a network protocol specification such as this one.
 


### PR DESCRIPTION
Not sure how this gets translated but on the resulting page, the URL is currently missing a zero.  I presume this will fix it.  